### PR TITLE
Updated filter matching regex

### DIFF
--- a/nsx-get-rulesCount-v1.2.ps1
+++ b/nsx-get-rulesCount-v1.2.ps1
@@ -271,7 +271,7 @@ Process{
                         }
 
                         # If we see a line that looks like a fw export, grab that and run vsipioctl on it:
-                        if ($item -match '(?<=name: )(.*sfw.2)') {
+                        if ($item -match '(?<=name:\s+)(.*\.([2,4-9]|1[0-5]))$') {
 
                             $vmNic = $matches[0]
                             write-ToLog "Found dfw ruleset on VM $vmName via vnic '$($vmNic)'" -entryType SUCCESS


### PR DESCRIPTION
The total number of rules per host isn't just limited to DFW. It includes DFW, SI, IDS & IDFW. This change will match all filters on slots 2, 4 through to 15.

The following are ignored due to the following:
- Slot 0 is the ESXi firewall
- Slot 1 is the switch security module
- Slot 3 is unused