### PR TITLE
Updated check for valid filters returned

### DIFF
--- a/nsx-get-rulesCount-v1.2.ps1
+++ b/nsx-get-rulesCount-v1.2.ps1
@@ -256,9 +256,9 @@ Process{
                write-ToLog "Retrieving host dvfilters and processing the information..."
                $dvflist = Invoke-SSHCommand -SSHSession $ssh -Command "summarize-dvfilter"
     
-               if($dvflist.Output.Count -ge 1){
+               if (($dvflist.Output | % {$_ -match '(?<=name:\s+)(.*\.([2,4-9]|1[0-5]))$'}) -contains "True") {
               
-                   write-ToLog "Found '$($dvflist.Output.Count)' dvfilters on host '$($vmHost.Name)' that need to be processed."
+                   write-ToLog "Found 1 or more dvfilters on host '$($vmHost.Name)' that need to be processed."
 
                    # Parse each line in the summarize-dvfilter output
                    ForEach ($item in $dvflist.Output) {
@@ -300,7 +300,7 @@ Process{
                     } 
                 }#End for
             }else{
-                write-ToLog "Found no dvfilters on host '$($vmHost.Name)', the host will be skipped."
+                write-ToLog "Host '$($vmHost.Name)' returned no dvfilters, the host will be skipped."
             }
 
                #Test to see if ssh service was currently running.  if not, stop the service.


### PR DESCRIPTION
The output from the summarize-dvfilter command is being returned in a array, with each line of the output a new object in the array.

The check for the count of items in `$dvflist.Output` was counting the number of lines returned from the command, and not whether the command had any dvfilters that needed to be processed.

This change checks for the existence of any dvfilters that need to be processed in the returned output, rather than checking the line count, as even on a host without any DFW protected vNICs, the summarize-dvfilter command returned 18 lines of output.